### PR TITLE
Add HTTP_X_FORWARDED_PROTO support to OAuth

### DIFF
--- a/src/OAuth/OAuthRequest.php
+++ b/src/OAuth/OAuthRequest.php
@@ -38,10 +38,15 @@ class OAuthRequest {
       $scheme = (!isset($_SERVER['HTTPS']) || $_SERVER['HTTPS'] != "on")
                 ? 'http'
                 : 'https';
+      $port = $_SERVER['SERVER_PORT'];
+      if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && isset($_SERVER['HTTP_X_FORWARDED_PORT'])) {
+	    $scheme = $_SERVER['HTTP_X_FORWARDED_PROTO'];
+	    $port = $_SERVER['HTTP_X_FORWARDED_PORT'];
+      }
       $http_url = ($http_url) ? $http_url : $scheme .
                                 '://' . $_SERVER['SERVER_NAME'] .
                                 ':' .
-                                $_SERVER['SERVER_PORT'] .
+                                $port .
                                 $_SERVER['REQUEST_URI'];
       $http_method = ($http_method) ? $http_method : $_SERVER['REQUEST_METHOD'];
 


### PR DESCRIPTION
A tool provider behind a load balancer that passes requests internally over http will cause a "OAuth signature check failed" error. Check for a HTTP_X_FORWARDED_PROTO and HTTP_X_FORWARDED_PORT to build a correct request. Based off https://tracker.moodle.org/browse/MDL-49171